### PR TITLE
Allow to take replacement source from header

### DIFF
--- a/urlrewrite.go
+++ b/urlrewrite.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Config struct {
-	Regex       string `json:"regex,omitempty"       toml:"regex,omitempty"       yaml:"regex,omitempty"`
-	Replacement string `json:"replacement,omitempty" toml:"replacement,omitempty" yaml:"replacement,omitempty"`
+	SourceStringFromHeader string `json:"sourceStringFromHeader,omitempty" toml:"sourceStringFromHeader,omitempty" yaml:"sourceStringFromHeader,omitempty"`
+	Regex                  string `json:"regex,omitempty"                  toml:"regex,omitempty"                  yaml:"regex,omitempty"`
+	Replacement            string `json:"replacement,omitempty"            toml:"replacement,omitempty"            yaml:"replacement,omitempty"`
 }
 
 func CreateConfig() *Config {
@@ -17,8 +18,9 @@ func CreateConfig() *Config {
 }
 
 type rewriteRule struct {
-	regexp      *regexp.Regexp
-	replacement string
+	sourceStringFromHeader string
+	regexp                 *regexp.Regexp
+	replacement            string
 }
 
 type FullUrlRewrite struct {
@@ -35,8 +37,9 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 	}
 
 	rewriteRule := &rewriteRule{
-		regexp:      regexp,
-		replacement: config.Replacement,
+		sourceStringFromHeader: config.SourceStringFromHeader,
+		regexp:                 regexp,
+		replacement:            config.Replacement,
 	}
 
 	return &FullUrlRewrite{
@@ -54,20 +57,50 @@ func (fullUrlRewrite *FullUrlRewrite) ServeHTTP(rw http.ResponseWriter, req *htt
 	fullUrlRewrite.next.ServeHTTP(rw, newReq)
 }
 
-// rewriteRequestUrl rewrites request URL according to the given rule
-// and returns new request instance if the URL has been updated.
-func rewriteRequestUrl(originalRequest *http.Request, rule *rewriteRule) (*http.Request, error) {
+// getReplacementSource returns the replacement source which is either taken from the header or the original request URL.
+func getReplacementSource(headerName string, req *http.Request) []string {
+	// If header name is provided, return the value of the header
+	if headerName != "" {
+		canonicalHeaderName := http.CanonicalHeaderKey(headerName)
+
+		// Return the header value from the request if it exists
+		if headerValue, ok := req.Header[canonicalHeaderName]; ok {
+			return headerValue
+		}
+	}
+
+	// Otherwise, return original request URL
 	// Clone the URL to avoid mutating the original request
-	originalUrlCopy := *originalRequest.URL
+	originalUrlCopy := *req.URL
 
 	// Grab the Host from the request as it's not included in the URL
 	// since we're in the context of server request (we're acting as a proxy)
 	// and in such case URL only contains Path and RawQuery (see RFC 7230, Section 5.3).
-	originalUrlCopy.Host = originalRequest.Host
-	originalUrlStr := originalUrlCopy.String()
-	newUrlStr := rule.regexp.ReplaceAllString(originalUrlStr, rule.replacement)
+	originalUrlCopy.Host = req.Host
 
-	if newUrlStr != originalUrlStr {
+	return []string{originalUrlCopy.String()}
+}
+
+// replaceInSource replaces the first matching string in the source with the replacement string
+// and returns the resulting string and a boolean indicating if a replacement was made.
+func replaceInSource(source []string, rule *rewriteRule) (string, bool) {
+	for _, item := range source {
+		// Only replace the string if it matches the regex
+		if rule.regexp.MatchString(item) {
+			return rule.regexp.ReplaceAllString(item, rule.replacement), true
+		}
+	}
+
+	return "", false
+}
+
+// rewriteRequestUrl rewrites request URL according to the given rule
+// and returns new request instance if the URL has been updated.
+func rewriteRequestUrl(originalRequest *http.Request, rule *rewriteRule) (*http.Request, error) {
+	replacementSource := getReplacementSource(rule.sourceStringFromHeader, originalRequest)
+
+	// Attempt to rewrite the strings from the replacement source to produce the new URL
+	if newUrlStr, ok := replaceInSource(replacementSource, rule); ok {
 		// Create a new request with the new URL
 		newRequest, err := http.NewRequestWithContext(
 			originalRequest.Context(),

--- a/urlrewrite_test.go
+++ b/urlrewrite_test.go
@@ -81,12 +81,14 @@ func TestServeHTTPMapsRewriteErrorToInternalServerError(t *testing.T) {
 
 func TestURLRewrite(t *testing.T) {
 	cases := []struct {
-		name        string
-		originalUrl string
-		regex       string
-		replacement string
-		expectedUrl string
-		expectedErr string
+		name                   string
+		originalUrl            string
+		headers                map[string]string
+		sourceStringFromHeader string
+		regex                  string
+		replacement            string
+		expectedUrl            string
+		expectedErr            string
 	}{
 		{
 			name:        "Simple string replacement",
@@ -136,14 +138,44 @@ func TestURLRewrite(t *testing.T) {
 			expectedUrl: "//cust-company1.example.com/company1/hello",
 			expectedErr: "",
 		},
+		{
+			name:        "Regex replacement: take the source string from header",
+			originalUrl: "//example.com/hello?param=234&another=123",
+			headers: map[string]string{
+				"Host":            "example.com",
+				"X-Original-Host": "another-company.com",
+			},
+			sourceStringFromHeader: "X-Original-Host",
+			regex:                  "^(.+)\\.com$",
+			replacement:            "//example.com/$1",
+			expectedUrl:            "//example.com/another-company",
+			expectedErr:            "",
+		},
+		{
+			name:        "Regex replacement: should not rewrite URL if no sources matched the regex",
+			originalUrl: "//example.com/hello?param=234&another=123",
+			headers: map[string]string{
+				"Host":            "example.com",
+				"X-Original-Host": "another-company.com",
+			},
+			sourceStringFromHeader: "X-Original-Host",
+			regex:                  "^(.+)\\.nl$",
+			replacement:            "//example.com/$1",
+			expectedUrl:            "//example.com/hello?param=234&another=123",
+			expectedErr:            "",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", tc.originalUrl, nil)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
 			rule := &rewriteRule{
-				regexp:      regexp.MustCompile(tc.regex),
-				replacement: tc.replacement,
+				sourceStringFromHeader: tc.sourceStringFromHeader,
+				regexp:                 regexp.MustCompile(tc.regex),
+				replacement:            tc.replacement,
 			}
 
 			newReq, err := rewriteRequestUrl(req, rule)


### PR DESCRIPTION
This change allows to take regex replacement source string from an arbitrary header in addition to request URL.