### PR TITLE
Mutate, rather than replace, original request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/e-flux-platform/full-url-rewrite-traefik-plugin
 
 go 1.24.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/urlrewrite.go
+++ b/urlrewrite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 )
 
@@ -99,24 +100,16 @@ func replaceInSource(source []string, rule *rewriteRule) (string, bool) {
 func rewriteRequestUrl(originalRequest *http.Request, rule *rewriteRule) (*http.Request, error) {
 	replacementSource := getReplacementSource(rule.sourceStringFromHeader, originalRequest)
 
-	// Attempt to rewrite the strings from the replacement source to produce the new URL
-	if newUrlStr, ok := replaceInSource(replacementSource, rule); ok {
-		// Create a new request with the new URL
-		newRequest, err := http.NewRequestWithContext(
-			originalRequest.Context(),
-			originalRequest.Method,
-			newUrlStr,
-			originalRequest.Body,
-		)
+	// Attempt to rewrite the strings from the replacement source to produce the new URL:
+	if newURLStr, ok := replaceInSource(replacementSource, rule); ok {
+		// Attempt to parse the new URL:
+		newURL, err := url.Parse(newURLStr)
 		if err != nil {
-			return nil, fmt.Errorf("error initializing request with new URL %q: %w", newUrlStr, err)
+			return nil, fmt.Errorf("error initializing request with new URL %q: %w", newURLStr, err)
 		}
-
-		newRequest.RequestURI = newRequest.URL.RequestURI()
-		newRequest.Header = originalRequest.Header.Clone()
-		newRequest.RemoteAddr = originalRequest.RemoteAddr
-
-		return newRequest, nil
+		// Mutate the original request, rather than recreating, to persist metadata:
+		originalRequest.URL = newURL
+		originalRequest.RequestURI = originalRequest.URL.RequestURI()
 	}
 
 	return originalRequest, nil

--- a/urlrewrite_test.go
+++ b/urlrewrite_test.go
@@ -1,11 +1,15 @@
 package full_url_rewrite_traefik_plugin
 
 import (
-	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSuccessfulInitialization(t *testing.T) {
@@ -14,11 +18,8 @@ func TestSuccessfulInitialization(t *testing.T) {
 		Replacement: "//example.com/path",
 	}
 
-	_, err := New(context.TODO(), nil, config, "test")
-
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
+	_, err := New(t.Context(), nil, config, "test")
+	require.NoError(t, err)
 }
 
 func TestInvalidRegexpInitialization(t *testing.T) {
@@ -27,11 +28,8 @@ func TestInvalidRegexpInitialization(t *testing.T) {
 		Replacement: "Something",
 	}
 
-	_, err := New(context.TODO(), nil, config, "test")
-
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	_, err := New(t.Context(), nil, config, "test")
+	require.Error(t, err)
 }
 
 func TestServeHTTPSuccessfullyRewritesRequestUrl(t *testing.T) {
@@ -42,23 +40,18 @@ func TestServeHTTPSuccessfullyRewritesRequestUrl(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check the new request URL is what we expect.
-		if r.URL.String() != "//example.com/world" {
-			t.Errorf("handler returned unexpected URL: expected %v, got %v", "//example.com/world", r.URL.String())
-		}
-
+		assert.Equal(t, "//example.com/world", r.URL.String())
 		_, _ = w.Write([]byte("OK"))
 	})
 
-	plugin, _ := New(context.TODO(), testHandler, config, "test")
-	req, _ := http.NewRequest("GET", "//example.com/hello", nil)
+	plugin, err := New(t.Context(), testHandler, config, "test")
+	require.NoError(t, err)
+	req, err := http.NewRequest("GET", "//example.com/hello", nil)
+	require.NoError(t, err)
 
 	plugin.ServeHTTP(rr, req)
 
-	// Check the status code is what we expect.
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: expected %v, got %v", http.StatusOK, status)
-	}
+	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestServeHTTPMapsRewriteErrorToInternalServerError(t *testing.T) {
@@ -68,15 +61,14 @@ func TestServeHTTPMapsRewriteErrorToInternalServerError(t *testing.T) {
 	}
 
 	rr := httptest.NewRecorder()
-	plugin, _ := New(context.TODO(), nil, config, "test")
-	req, _ := http.NewRequest("GET", "//example.com/hello", nil)
+	plugin, err := New(t.Context(), nil, config, "test")
+	require.NoError(t, err)
+	req, err := http.NewRequest("GET", "//example.com/hello", nil)
+	require.NoError(t, err)
 
 	plugin.ServeHTTP(rr, req)
 
-	// Check the status code is what we expect.
-	if status := rr.Code; status != http.StatusInternalServerError {
-		t.Errorf("handler returned wrong status code: expected %v, got %v", http.StatusInternalServerError, status)
-	}
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }
 
 func TestURLRewrite(t *testing.T) {
@@ -168,7 +160,8 @@ func TestURLRewrite(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, _ := http.NewRequest("GET", tc.originalUrl, nil)
+			req, err := http.NewRequest("GET", tc.originalUrl, nil)
+			require.NoError(t, err)
 			for k, v := range tc.headers {
 				req.Header.Set(k, v)
 			}
@@ -179,18 +172,67 @@ func TestURLRewrite(t *testing.T) {
 			}
 
 			newReq, err := rewriteRequestUrl(req, rule)
-			if err != nil {
-				if err.Error() != tc.expectedErr {
-					t.Fatalf("expected error to be: %v, got: %v", tc.expectedErr, err)
-				}
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.expectedErr, err.Error())
 				return
 			}
-
-			updatedUrl := newReq.URL.String()
-			if updatedUrl != tc.expectedUrl {
-				t.Fatalf("expected URL to be: %v, got: %v", tc.expectedUrl, updatedUrl)
-				return
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedUrl, newReq.URL.String())
 		})
 	}
+}
+
+func TestGetBody(t *testing.T) {
+	rule := &rewriteRule{
+		regexp:      regexp.MustCompile("hello"),
+		replacement: "goodbye",
+	}
+
+	const payload = "important"
+
+	req, err := http.NewRequest("POST", "//example.com/hello", strings.NewReader(payload))
+	require.NoError(t, err)
+	require.NotNil(t, req.GetBody, "incoming client-style request exposes GetBody for reopening")
+
+	out, err := rewriteRequestUrl(req, rule)
+	require.NoError(t, err)
+	assert.NotNil(t, out.GetBody)
+
+	// First read:
+	reader, err := out.GetBody()
+	require.NoError(t, err)
+	first, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(first))
+
+	// Second read:
+	reader, err = out.GetBody()
+	require.NoError(t, err)
+	second, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(second))
+}
+
+func TestContentLength(t *testing.T) {
+	rule := &rewriteRule{
+		regexp:      regexp.MustCompile("hello"),
+		replacement: "goodbye",
+	}
+
+	const payload = "important"
+
+	// Only io.Reader (wrapped by NopCloser), not *bytes.Buffer / *strings.Reader, so net/http
+	// cannot infer length and uses -1—while the reverse proxy may already know Content-Length.
+	opaque := struct{ io.Reader }{Reader: strings.NewReader(payload)}
+	req, err := http.NewRequest("POST", "//example.com/hello", io.NopCloser(opaque))
+	require.NoError(t, err)
+	req.ContentLength = int64(len(payload))
+
+	out, err := rewriteRequestUrl(req, rule)
+	require.NoError(t, err)
+
+	assert.Equal(t, req.ContentLength, out.ContentLength)
+	assert.Equal(t, int64(len(payload)), out.ContentLength)
+	assert.Nil(t, out.GetBody)
 }


### PR DESCRIPTION
Hi,

I noticed that the plugin was overwriting the request, which is causing some issues, as it doesn't perfectly "clone" the request. I've added a couple of tests (for `GetBody` and `ContentLength`) that highlight the issue; these both fail on the current version as expected, and are fixed with these changes. Some services use ContentLength to determine whether or not they need to read any data, so this is very important to keep.

The other tests all pass with mutation of the original request as well.

Let me know what you think - I'm interested to know why a new request was chosen, rather than just mutating the original.

Thanks,
Evyn